### PR TITLE
Add docker compose tasks to debug commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,8 @@
             "type": "python",
             "request": "launch",
             "module": "flask",
+            "preLaunchTask": "db-up",
+            "postDebugTask": "db-down",
             "env": {
                 "FLASK_APP": "src/app.py",
                 "FLASK_DEBUG": "1"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "db-up",
+            "type": "docker-compose",
+            "dockerCompose": {
+                "up": {
+                    "detached": true,
+                    "build": true
+                },
+                "files": [
+                    "${workspaceFolder}/compose.yaml"
+                ]
+            }
+        },
+        {
+            "label": "db-down",
+            "type": "docker-compose",
+            "dockerCompose": {
+                "down": {},
+                "files": [
+                    "${workspaceFolder}/compose.yaml"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The need to have the database running all the time was dumb. This way it will only create and run the database when required. The data will still persist in the volume mount, but no CPU cycles will be used by the postgres container when it isn't needed